### PR TITLE
Simplify ZonedDateTime adapter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,9 +238,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.3.0</version>
                 <configuration>
                     <additionalparam>-Xdoclint:none</additionalparam>
+                    <failOnError>false</failOnError>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>11</jdk.version>
+        <slf4j.version>2.0.7</slf4j.version>
     </properties>
 
     <name>siri-java-model</name>
@@ -108,11 +109,22 @@
             <scope>test</scope>
             <version>2.1.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
         <!-- Test -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/org/entur/siri/adapter/ZonedDateTimeAdapter.java
+++ b/src/main/java/org/entur/siri/adapter/ZonedDateTimeAdapter.java
@@ -15,28 +15,30 @@
 
 package org.entur.siri.adapter;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Objects;
 
 public class ZonedDateTimeAdapter {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(ZonedDateTimeAdapter.class);
+
     /**
-     * Parses dateTime to ZonedDateTime with optional zone
+     * Parses dateTime to ZonedDateTime with optional zone.
+     * If Zone is not provided, local system default is used.
      *
-     * If Zone is not provided, local system default is used
-     *
-     * @param dateTime May be either ISO-formatted string, or timestamp in milliseconds
-     * @return
+     * @param dateTime Maybe either ISO-formatted string, or timestamp in milliseconds
      */
     public static ZonedDateTime parse(String dateTime) {
+        Objects.requireNonNull(dateTime, "dateTime");
         ZonedDateTime parsed;
-        if (dateTime!= null && isNumeric(dateTime)) {
-            parsed = parse(Long.valueOf(dateTime));
+        if (containsOnlyDigits(dateTime)) {
+            LOGGER.trace("ZoneDateTime provided as a timestamp: {}", dateTime);
+            parsed = parse(Long.parseLong(dateTime));
         } else {
             try {
                 parsed = ZonedDateTime.parse(dateTime);
@@ -49,18 +51,24 @@ public class ZonedDateTimeAdapter {
         return parsed.withZoneSameInstant(ZoneId.systemDefault());
     }
 
-    private static boolean isNumeric(String str)
-    {
-        return str.matches("\\d+");
+    private static boolean containsOnlyDigits(String str) {
+        int length = str.length();
+        if(length == 0) {
+            return false;
+        }
+        for (int i = 0; i < length; i++) {
+            if (str.charAt(i) < '0'
+                    || str.charAt(i) > '9') {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**
-     * Parses dateTime to ZonedDateTime with optional zone
+     * Parses dateTime to ZonedDateTime with optional zone.
+     * If Zone is not provided, local system default is used.
      *
-     * If Zone is not provided, local system default is used
-     *
-     * @param dateTime
-     * @return
      */
     private static ZonedDateTime parse(long dateTime) {
         return ZonedDateTime.ofInstant(Instant.ofEpochSecond(dateTime), ZoneId.systemDefault());

--- a/src/test/java/org/entur/siri/adapter/ZonedDateTimeAdapterTest.java
+++ b/src/test/java/org/entur/siri/adapter/ZonedDateTimeAdapterTest.java
@@ -15,13 +15,16 @@
 
 package org.entur.siri.adapter;
 
-import junit.framework.TestCase;
 import org.junit.Test;
 
+import java.time.Month;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 
-public class ZonedDateTimeAdapterTest extends TestCase {
+import static org.junit.Assert.*;
+
+public class ZonedDateTimeAdapterTest {
 
     @Test
     public void testParseDifferentZones() {
@@ -43,4 +46,31 @@ public class ZonedDateTimeAdapterTest extends TestCase {
         assertTrue(localZoneTime.isEqual(utcTime));
         assertTrue(localZoneTime.isEqual(otherZoneTime));
     }
+
+    @Test
+    public void testParseTimestamps() {
+        ZonedDateTime utcTime = ZonedDateTimeAdapter.parse("1690419600");
+        assertEquals(2023, utcTime.getYear());
+        assertEquals(Month.JULY, utcTime.getMonth());
+        assertEquals(27, utcTime.getDayOfMonth());
+
+    }
+
+    @Test
+    public void testParseInvalid() {
+        assertThrows(DateTimeParseException.class, ()-> ZonedDateTimeAdapter.parse("XXX"));
+    }
+
+    @Test
+    public void testParseEmpty() {
+        assertThrows(DateTimeParseException.class, ()-> ZonedDateTimeAdapter.parse(""));
+    }
+
+    @Test
+    public void testParseNull() {
+        assertThrows(NullPointerException.class, ()-> ZonedDateTimeAdapter.parse(null));
+    }
+
+
+
 }


### PR DESCRIPTION
- Use a more efficient parsing for ZonedDateTime provided as timestamp
- Add logging to monitor the use of ZonedDateTime provided as timestamp