### PR TITLE
Remove support for ZonedDateTime as timestamp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,53 @@ aliases:
     command: |
       echo $SONATYPE_GPG_KEY_BASE64 | base64 --decode | gpg --batch --no-tty --import --yes
 jobs:
+
+  test:
+    docker:
+      - image: cimg/openjdk:11.0
+        auth:
+          username: $DOCKERHUB_LOGIN
+          password: $DOCKERHUB_PASSWORD
+    environment:
+      MAVEN_OPTS: -Xmx3G
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - dep-cache-{{ checksum "pom.xml" }}
+            # fallback to the most recent cache if there is no exact match for this pom.xml
+            - dep-cache-
+      - run:
+          name: Download Maven settings
+          command: wget https://raw.githubusercontent.com/entur/circleci-toolbox-image-java11/master/tools/m2/settings.xml -O .circleci/settings.xml
+      - run: *jfrog-login
+      - run:
+          name: Refresh cache
+          command: mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.0:go-offline -s .circleci/settings.xml
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: dep-cache-{{ checksum "pom.xml" }}
+      # Cannot use -o because of snapshot dependencies.
+      - run:
+          name: Run Maven verify
+          command: mvn verify -s .circleci/settings.xml
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/junit/
+            find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/junit/ \;
+          when: always
+      - store_test_results:
+          path: ~/junit
+      - store_artifacts:
+          path: ~/junit
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - target
+            - .circleci
+
   deploy:
     docker:
       - image: cimg/openjdk:11.0
@@ -60,8 +107,13 @@ workflows:
   version: 2
   build_deploy:
     jobs:
+      - test:
+          context:
+            global
       - deploy:
           context: global
+          requires:
+            - test
           filters:
             branches:
               only: master

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.3</version>
+        <version>2.7.18</version>
     </parent>
 
     <groupId>org.entur</groupId>
@@ -170,9 +170,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M1</version>
+                <version>3.2.3</version>
                 <configuration>
-                    <skipTests>true</skipTests>
+                    <argLine>-Duser.timezone=Europe/Oslo</argLine>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/entur/siri/adapter/ZonedDateTimeAdapter.java
+++ b/src/main/java/org/entur/siri/adapter/ZonedDateTimeAdapter.java
@@ -15,9 +15,6 @@
 
 package org.entur.siri.adapter;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -25,52 +22,23 @@ import java.util.Objects;
 
 public class ZonedDateTimeAdapter {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ZonedDateTimeAdapter.class);
-
     /**
      * Parses dateTime to ZonedDateTime with optional zone.
      * If Zone is not provided, local system default is used.
      *
-     * @param dateTime Maybe either ISO-formatted string, or timestamp in milliseconds
+     * @param dateTime ISO-formatted string
      */
     public static ZonedDateTime parse(String dateTime) {
         Objects.requireNonNull(dateTime, "dateTime");
         ZonedDateTime parsed;
-        if (containsOnlyDigits(dateTime)) {
-            LOGGER.trace("ZoneDateTime provided as a timestamp: {}", dateTime);
-            parsed = parse(Long.parseLong(dateTime));
-        } else {
-            try {
-                parsed = ZonedDateTime.parse(dateTime);
-            } catch (DateTimeParseException e) {
-                LocalDateTime parse1 = LocalDateTime.parse(dateTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
-                parsed = ZonedDateTime.ofLocal(parse1, ZoneId.systemDefault(), ZoneOffset.ofHours(0));
+        try {
+            parsed = ZonedDateTime.parse(dateTime);
+        } catch (DateTimeParseException e) {
+            LocalDateTime parse1 = LocalDateTime.parse(dateTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+            parsed = ZonedDateTime.ofLocal(parse1, ZoneId.systemDefault(), ZoneOffset.ofHours(0));
 
-            }
         }
         return parsed.withZoneSameInstant(ZoneId.systemDefault());
     }
 
-    private static boolean containsOnlyDigits(String str) {
-        int length = str.length();
-        if(length == 0) {
-            return false;
-        }
-        for (int i = 0; i < length; i++) {
-            if (str.charAt(i) < '0'
-                    || str.charAt(i) > '9') {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * Parses dateTime to ZonedDateTime with optional zone.
-     * If Zone is not provided, local system default is used.
-     *
-     */
-    private static ZonedDateTime parse(long dateTime) {
-        return ZonedDateTime.ofInstant(Instant.ofEpochSecond(dateTime), ZoneId.systemDefault());
-    }
 }

--- a/src/test/java/org/entur/siri/adapter/ZonedDateTimeAdapterTest.java
+++ b/src/test/java/org/entur/siri/adapter/ZonedDateTimeAdapterTest.java
@@ -48,15 +48,6 @@ public class ZonedDateTimeAdapterTest {
     }
 
     @Test
-    public void testParseTimestamps() {
-        ZonedDateTime utcTime = ZonedDateTimeAdapter.parse("1690419600");
-        assertEquals(2023, utcTime.getYear());
-        assertEquals(Month.JULY, utcTime.getMonth());
-        assertEquals(27, utcTime.getDayOfMonth());
-
-    }
-
-    @Test
     public void testParseInvalid() {
         assertThrows(DateTimeParseException.class, ()-> ZonedDateTimeAdapter.parse("XXX"));
     }


### PR DESCRIPTION
Providing ZonedDateTime as a timestamp is not supported by the SIRI XML schema.
This PR removes support for this feature.